### PR TITLE
Fix error when using the API client without a League provider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
-.idea
+.idea/
+composer.lock
+vendor/

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@
 
 ### 1. Create a Guzzle client
 https://github.com/guzzle/guzzle
-```
+
+```php
 use GuzzleHttp\Client;
 
 $baseUrl = 'https://<TRACARDI_API_URL>';
@@ -16,7 +17,8 @@ $client = new Client([
 
 ### 2. Create the OAuth2 provider & retrieve an access token
 https://github.com/thephpleague/oauth2-client
-```
+
+```php
 use League\OAuth2\Client\Provider\GenericProvider;
 
 $provider = new GenericProvider([
@@ -32,7 +34,8 @@ $accessToken = $provider->getAccessToken('password', [
 ```
 
 ### 3. Combine the above to get the Tracardi client
-```
+
+```php
 use Http\Adapter\Guzzle6\Client as ClientAdapter;
 use Tracardi\TracardiPhpSdk\Http\ApiClient\ApiClient;
 
@@ -41,7 +44,8 @@ $apiClient = ApiClient::withProvider($psrClient, $provider, $accessToken);
 ```
 
 ### 4. Start using the repositories
-```
+
+```php
 use Tracardi\TracardiPhpSdk\Tracardi;
 
 $profile = Tracardi::withDefaultSerializer($apiClient)
@@ -49,7 +53,7 @@ $profile = Tracardi::withDefaultSerializer($apiClient)
   ->getProfile('<ID>');
 ```
 
-## 5. Using your own HTTP client
+### 5. Using your own HTTP client
 
 It is not strictly required to use the League OAuth provider, alternatively you can
 instantiate the API client with an HTTP client only. It is your own responsibility that

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ use Http\Adapter\Guzzle6\Client as ClientAdapter;
 use Tracardi\TracardiPhpSdk\Http\ApiClient\ApiClient;
 
 $psrClient = new ClientAdapter($client);
-$apiClient = new ApiClient($provider, $psrClient, $accessToken);
+$apiClient = ApiClient::withProvider($psrClient, $provider, $accessToken);
 ```
 
 ### 4. Start using the repositories
@@ -47,4 +47,40 @@ use Tracardi\TracardiPhpSdk\Tracardi;
 $profile = Tracardi::withDefaultSerializer($apiClient)
   ->profiles()
   ->getProfile('<ID>');
+```
+
+## 5. Using your own HTTP client
+
+It is not strictly required to use the League OAuth provider, alternatively you can
+instantiate the API client with an HTTP client only. It is your own responsibility that
+this HTTP client performs authenticated requests.
+
+This flow requires some PSR-7 request factory to be present, e.g. `composer require nyholm/psr7`.
+See the [php-http docs](https://docs.php-http.org/en/latest/discovery.html) for more information.
+
+```php
+use Http\Adapter\Guzzle6\Client as ClientAdapter;
+use Tracardi\TracardiPhpSdk\Http\ApiClient\ApiClient;
+use GuzzleHttp\Client;
+use GuzzleHttp\HandlerStack;
+
+// When using Guzzle you could create your own custom middleware
+// that fetches the access token from e.g. the database.
+$middleware = function (callable $handler): callable {
+  return function (RequestInterface $request, array $options) use ($handler) {
+    $request = $request->withHeader('Authorization', 'Bearer ' . fetchToken());
+
+    return $handler($request, $options);
+  };
+};
+$stack = HandlerStack::create();
+$stack->push($middleware);
+
+$client = new Client([
+  'base_uri' => 'https://<TRACARDI_API_URL>',
+  'handler' => $stack
+]);
+
+$psrClient = new ClientAdapter($client);
+$apiClient = ApiClient::withClient($psrClient);
 ```

--- a/composer.json
+++ b/composer.json
@@ -9,11 +9,17 @@
         "php-http/httplug": "^2.2",
         "league/oauth2-client": "^2.6",
         "phpdocumentor/reflection-docblock": "^5.2",
-        "symfony/property-info": "^4.0"
+        "symfony/property-info": "^4.0",
+        "psr/http-client-implementation": "^1.0",
+        "php-http/message-factory": "^1.0",
+        "php-http/discovery": "^1.14"
     },
     "autoload": {
         "psr-4": {
             "Tracardi\\TracardiPhpSdk\\": "src/"
         }
+    },
+    "suggest": {
+        "nyholm/psr7": "When not using the League OAuth provider, this SDK requires a PSR-7 compliant request factory."
     }
 }


### PR DESCRIPTION
The API client seemingly supported usage without a League provider but actually doing so resulted in an error. This commit fixes the error and adds an example in the README.

We introduce a breaking change: the constructor parameters of the `ApiClient` are reordered so optional parameters come after required ones. This shouldn't be too big of an issue since we're not on a stable version yet.