### PR TITLE
Create a custom provider to instantiate the API client

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 ## Getting started
 
 ### 1. Create a Guzzle client
+
 https://github.com/guzzle/guzzle
 
 ```php
@@ -16,16 +17,13 @@ $client = new Client([
 ```
 
 ### 2. Create the OAuth2 provider & retrieve an access token
+
 https://github.com/thephpleague/oauth2-client
 
 ```php
-use League\OAuth2\Client\Provider\GenericProvider;
+use Tracardi\TracardiPhpSdk\OAuth2\Provider\TracardiProvider;
 
-$provider = new GenericProvider([
-  'urlAuthorize' => $baseUrl . '/authorize',
-  'urlAccessToken' => $baseUrl . '/token',
-  'urlResourceOwnerDetails' => $baseUrl. '/resource',
-]);
+$provider = new TracardiProvider(['baseUrl' => $baseUrl]);
 
 $accessToken = $provider->getAccessToken('password', [
   'username' => '<USERNAME>',

--- a/src/OAuth2/Provider/TracardiProvider.php
+++ b/src/OAuth2/Provider/TracardiProvider.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Tracardi\TracardiPhpSdk\OAuth2\Provider;
+
+use League\OAuth2\Client\Provider\GenericProvider;
+
+class TracardiProvider extends GenericProvider
+{
+  public function __construct(array $options = [], array $collaborators = []) {
+    $baseUrl = $options['baseUrl'];
+    if (!is_string($baseUrl)) {
+      throw new \InvalidArgumentException("The 'baseUrl' option must be a string");
+    }
+
+    if (substr($baseUrl, -1) !== '/') {
+      $baseUrl .= '/';
+    }
+
+    $options['urlAuthorize'] = $options['urlAuthorize'] ?? $baseUrl . 'authorize';
+    $options['urlAccessToken'] = $options['urlAccessToken'] ?? $baseUrl . 'token';
+    $options['urlResourceOwnerDetails'] = $options['urlResourceOwnerDetails'] ?? $baseUrl . 'resource';
+
+    parent::__construct($options);
+  }
+
+  protected function getRequiredOptions(): array {
+    return ['baseUrl'];
+  }
+
+  protected function getConfigurableOptions(): array {
+    $defaultOptions = parent::getConfigurableOptions();
+    $newOptionalOptions = [
+      'urlAuthorize',
+      'urlAccessToken',
+      'urlResourceOwnerDetails'
+    ];
+
+    return array_merge($defaultOptions, $newOptionalOptions);
+  }
+}


### PR DESCRIPTION
This is a small QOL change for end users of the SDK. Instead of using a `GenericProvider`, we provide a specific `TracardiProvider` that points to the correct endpoints. So instead of this:

```php
$provider = new GenericProvider([
  'urlAuthorize' => $baseUrl . '/authorize',
  'urlAccessToken' => $baseUrl . '/token',
  'urlResourceOwnerDetails' => $baseUrl. '/resource',
]);
```

Users can now simply do:

```php
$provider = new TracardiProvider(['baseUrl' => $baseUrl]);
```